### PR TITLE
Work with uploaded benchmark variables

### DIFF
--- a/pbs_server/data/albedo.cfg.tmpl
+++ b/pbs_server/data/albedo.cfg.tmpl
@@ -12,3 +12,4 @@ weight = 20
 [MODIS]
 source = "DATA/albedo/MODIS/albedo_0.5x0.5.nc"
 weight = 20
+

--- a/pbs_server/data/biomass.cfg.tmpl
+++ b/pbs_server/data/biomass.cfg.tmpl
@@ -31,3 +31,4 @@ weight = 8
 table_unit = "Pg"
 plot_unit  = "kg m-2"
 space_mean = False
+

--- a/pbs_server/data/gpp.cfg.tmpl
+++ b/pbs_server/data/gpp.cfg.tmpl
@@ -17,3 +17,4 @@ table_unit = "Pg yr-1"
 plot_unit = "g m-2 d-1"
 space_mean = False
 skip_iav = True
+

--- a/pbs_server/data/lai.cfg.tmpl
+++ b/pbs_server/data/lai.cfg.tmpl
@@ -12,3 +12,4 @@ weight = 15
 source = "DATA/lai/MODIS/lai_0.5x0.5.nc"
 weight = 15
 skip_iav = True
+

--- a/pbs_server/data/le.cfg.tmpl
+++ b/pbs_server/data/le.cfg.tmpl
@@ -15,3 +15,4 @@ land = True
 weight = 9
 table_unit = "W m-2"
 plot_unit = "W m-2"
+

--- a/pbs_server/data/nee.cfg.tmpl
+++ b/pbs_server/data/nee.cfg.tmpl
@@ -16,3 +16,4 @@ table_unit = "Pg yr-1"
 plot_unit = "g m-2 d-1"
 space_mean = False
 skip_iav = True
+

--- a/pbs_server/data/nep.cfg.tmpl
+++ b/pbs_server/data/nep.cfg.tmpl
@@ -17,3 +17,4 @@ table_unit = "Pg yr-1"
 plot_unit  = "g m-2 d-1"
 space_mean = False
 skip_iav = True
+

--- a/pbs_server/data/pr.cfg.tmpl
+++ b/pbs_server/data/pr.cfg.tmpl
@@ -33,3 +33,4 @@ weight = 20
 table_unit = "mm d-1"
 plot_unit = "mm d-1"
 space_mean = True
+

--- a/pbs_server/data/reco.cfg.tmpl
+++ b/pbs_server/data/reco.cfg.tmpl
@@ -16,3 +16,4 @@ table_unit = "Pg yr-1"
 plot_unit = "g m-2 d-1"
 space_mean = False
 skip_iav = True
+

--- a/pbs_server/data/rsds.cfg.tmpl
+++ b/pbs_server/data/rsds.cfg.tmpl
@@ -16,3 +16,4 @@ weight = 15
 [WRMC.BSRN]
 source = "DATA/rsds/WRMC.BSRN/rsds.nc"
 weight = 12
+

--- a/pbs_server/data/rsus.cfg.tmpl
+++ b/pbs_server/data/rsus.cfg.tmpl
@@ -12,3 +12,4 @@ weight = 15
 [WRMC.BSRN]
 source = "DATA/rsus/WRMC.BSRN/rsus.nc"
 weight = 12
+

--- a/pbs_server/data/tas.cfg.tmpl
+++ b/pbs_server/data/tas.cfg.tmpl
@@ -8,3 +8,4 @@ weight = 25
 [Fluxnet]
 source = "DATA/tas/FLUXNET/tas.nc"
 weight = 9
+

--- a/pbs_server/models.py
+++ b/pbs_server/models.py
@@ -7,7 +7,7 @@ model_template = { "group": { "name": "pbs_models_group", "members":
     "description": "{model_name}" }
 
 
-def get_model_name(pbs_file):
+def get_name(pbs_file):
     """
     Extract the model name from a CMIP5-compatible filename.
 

--- a/pbs_server/models.py
+++ b/pbs_server/models.py
@@ -58,7 +58,7 @@ def update_parameters(parameters, models):
 
     Parameters
     ----------
-    parameters : dict
+    parameters : list
       The contents of the ILAMB `parameters.json` file.
     models : list
       A list of model names whose output has been uploaded into the PBS.

--- a/pbs_server/tests/test_models.py
+++ b/pbs_server/tests/test_models.py
@@ -3,7 +3,7 @@
 import os
 import json
 from nose.tools import raises, assert_equal, assert_true, assert_false
-from pbs_server.models import (get_model_name, is_key_in_pbs_group,
+from pbs_server.models import (get_name, is_key_in_pbs_group,
                                update_parameters)
 from pbs_server import data_directory
 
@@ -22,14 +22,14 @@ with open(parameters_file, 'r') as fp:
     parameters = json.load(fp)
 
 
-def test_get_model_name_pass():
-    name = get_model_name(pbs_file_good)
+def test_get_name_pass():
+    name = get_name(pbs_file_good)
     assert_equal(model_name, name)
 
 
 @raises(IndexError)
-def test_get_model_name_fail():
-    name = get_model_name(pbs_file_bad)
+def test_get_name_fail():
+    name = get_name(pbs_file_bad)
 
 
 def test_key_in_pbs_group():

--- a/pbs_server/tests/test_variables.py
+++ b/pbs_server/tests/test_variables.py
@@ -1,0 +1,13 @@
+"""Tests for the variables module."""
+
+from nose.tools import assert_equal
+from pbs_server.variables import get_variable_name
+
+
+variable_file = 'gpp_0.5x0.5.nc'
+variable_name = 'gpp'
+
+
+def test_get_variable_name():
+    name = get_variable_name(variable_file)
+    assert_equal(variable_name, name)

--- a/pbs_server/tests/test_variables.py
+++ b/pbs_server/tests/test_variables.py
@@ -1,21 +1,38 @@
 """Tests for the variables module."""
 
 import os
+import shutil
 import json
+from ConfigParser import SafeConfigParser
 from nose.tools import assert_equal, assert_true, assert_false
-from pbs_server.variables import get_name, update_parameters
+from pbs_server.variables import (get_name, update_parameters,
+                                  update_template)
 from pbs_server import data_directory
 
 
 variable_file = 'gpp_0.5x0.5.nc'
 variable_name = 'gpp'
-existing_var = 'tas'
-new_var = 'nep'
-variables = [existing_var, new_var]
+old_var = 'tas'
+new_var = 'foo'
+variables = [old_var, new_var]
+old_tmpl_file = os.path.join(data_directory,
+                             '{}.cfg.tmpl'.format(old_var))
+old_tmpl_file_copy = '{}.copy'.format(old_tmpl_file)
+new_tmpl_file = os.path.join(data_directory,
+                             '{}.cfg.tmpl'.format(new_var))
 
 parameters_file = os.path.join(data_directory, 'parameters.json')
 with open(parameters_file, 'r') as fp:
     parameters = json.load(fp)
+
+
+def setup_module():
+    shutil.copy(old_tmpl_file, old_tmpl_file_copy)
+
+
+def teardown_module():
+    shutil.move(old_tmpl_file_copy, old_tmpl_file)
+    os.remove(new_tmpl_file)
 
 
 def test_get_name():
@@ -33,4 +50,18 @@ def test_update_parameters():
     update_parameters(parameters, variables)
     for param in parameters:
         if param['key'] == '_variable1':
-            assert_true(existing_var in param['value']['choices'])
+            assert_true(old_var in param['value']['choices'])
+
+
+def test_create_template():
+    update_template(new_var, '{}.nc'.format(new_var))
+    config = SafeConfigParser()
+    config.read(new_tmpl_file)
+    assert_true(config.has_section('PBS'))
+
+
+def test_update_template():
+    update_template(old_var, '{}.nc'.format(old_var))
+    config = SafeConfigParser()
+    config.read(old_tmpl_file)
+    assert_true(config.has_section('PBS'))

--- a/pbs_server/tests/test_variables.py
+++ b/pbs_server/tests/test_variables.py
@@ -1,13 +1,13 @@
 """Tests for the variables module."""
 
 from nose.tools import assert_equal
-from pbs_server.variables import get_variable_name
+from pbs_server.variables import get_name
 
 
 variable_file = 'gpp_0.5x0.5.nc'
 variable_name = 'gpp'
 
 
-def test_get_variable_name():
-    name = get_variable_name(variable_file)
+def test_get_name():
+    name = get_name(variable_file)
     assert_equal(variable_name, name)

--- a/pbs_server/tests/test_variables.py
+++ b/pbs_server/tests/test_variables.py
@@ -1,13 +1,36 @@
 """Tests for the variables module."""
 
-from nose.tools import assert_equal
-from pbs_server.variables import get_name
+import os
+import json
+from nose.tools import assert_equal, assert_true, assert_false
+from pbs_server.variables import get_name, update_parameters
+from pbs_server import data_directory
 
 
 variable_file = 'gpp_0.5x0.5.nc'
 variable_name = 'gpp'
+existing_var = 'tas'
+new_var = 'nep'
+variables = [existing_var, new_var]
+
+parameters_file = os.path.join(data_directory, 'parameters.json')
+with open(parameters_file, 'r') as fp:
+    parameters = json.load(fp)
 
 
 def test_get_name():
     name = get_name(variable_file)
     assert_equal(variable_name, name)
+
+
+def test_update_parameters_pretest():
+    for param in parameters:
+        if param['key'] == '_variable1':
+            assert_false(new_var in param['value']['choices'])
+
+
+def test_update_parameters():
+    update_parameters(parameters, variables)
+    for param in parameters:
+        if param['key'] == '_variable1':
+            assert_true(existing_var in param['value']['choices'])

--- a/pbs_server/variables.py
+++ b/pbs_server/variables.py
@@ -2,6 +2,11 @@
 
 import os
 import bisect
+from ConfigParser import SafeConfigParser
+from . import data_directory
+
+
+pbs_data_dir = os.path.join('DATA-by-project', 'PBS')
 
 
 def get_name(pbs_file):
@@ -48,3 +53,40 @@ def update_parameters(parameters, variables):
                 for variable in variables:
                     if variable not in param['value']['choices']:
                         bisect.insort(param['value']['choices'], variable)
+
+
+def update_template(variable_name, file_name):
+    """Create or update the .cfg.tmpl file for a variable.
+
+    Parameters
+    ----------
+    variable_name : str
+      A CMIP5 short variable name.
+    file_name : str
+      The path to the file on the PBS server.
+
+    """
+    base_file = variable_name + '.cfg.tmpl'
+    tmpl_file = os.path.join(data_directory, base_file)
+    tmpl_file_exists = os.path.exists(tmpl_file)
+    config_update = SafeConfigParser()
+
+    # If the file is new, add an [h2] entry.
+    if not tmpl_file_exists:
+        h2_section = 'h2: {}'.format(variable_name)
+        config_update.add_section(h2_section)
+        config_update.set(h2_section, 'variable', '"{}"'.format(variable_name))
+
+    config_existing = SafeConfigParser()
+    if tmpl_file_exists:
+        config_existing.read(tmpl_file)
+
+    # If a [PBS] entry doesn't exist, make it.
+    pbs_section = 'PBS'
+    if not config_existing.has_section(pbs_section):
+        config_update.add_section(pbs_section)
+        config_update.set(pbs_section, 'source',
+                          '"{}"'.format(os.path.join(pbs_data_dir, file_name)))
+
+    with open(tmpl_file, 'a') as fp:
+        config_update.write(fp)

--- a/pbs_server/variables.py
+++ b/pbs_server/variables.py
@@ -1,6 +1,7 @@
 """Perform operations on benchmark data uploaded through PBS."""
 
 import os
+import bisect
 
 
 def get_name(pbs_file):
@@ -22,3 +23,28 @@ def get_name(pbs_file):
     parts = base.split('_')
     name = parts[0]
     return name
+
+
+def update_parameters(parameters, variables):
+    """
+    Adds new variable names the set of ILAMB parameters.
+
+    Parameters
+    ----------
+    parameters : list
+      The contents of the ILAMB `parameters.json` file.
+    variables : list
+      A list of CMIP5 short variable names.
+
+    Notes
+    -----
+    The parameters list is updated by reference.
+
+    """
+    variable_list_keys = ['_variable' + str(i) for i in range(1,4)]
+    for param in parameters:
+        for variable_list_key in variable_list_keys:
+            if param['key'] == variable_list_key:
+                for variable in variables:
+                    if variable not in param['value']['choices']:
+                        bisect.insort(param['value']['choices'], variable)

--- a/pbs_server/variables.py
+++ b/pbs_server/variables.py
@@ -1,5 +1,8 @@
 """Perform operations on benchmark data uploaded through PBS."""
 
+import os
+
+
 def get_variable_name(pbs_file):
     """
     Extract the CMIP5 short variable name from a benchmark data filename.
@@ -15,6 +18,7 @@ def get_variable_name(pbs_file):
       The name of the variable.
 
     """
-    parts = pbs_file.split('_')
+    base, ext = os.path.splitext(pbs_file)
+    parts = base.split('_')
     name = parts[0]
     return name

--- a/pbs_server/variables.py
+++ b/pbs_server/variables.py
@@ -1,0 +1,20 @@
+"""Perform operations on benchmark data uploaded through PBS."""
+
+def get_variable_name(pbs_file):
+    """
+    Extract the CMIP5 short variable name from a benchmark data filename.
+
+    Parameters
+    ----------
+    pbs_file : str
+      A filename that looks like other ILAMB data filenames.
+
+    Returns
+    -------
+    str
+      The name of the variable.
+
+    """
+    parts = pbs_file.split('_')
+    name = parts[0]
+    return name

--- a/pbs_server/variables.py
+++ b/pbs_server/variables.py
@@ -3,7 +3,7 @@
 import os
 
 
-def get_variable_name(pbs_file):
+def get_name(pbs_file):
     """
     Extract the CMIP5 short variable name from a benchmark data filename.
 


### PR DESCRIPTION
This PR adds a new module, `variables`, with code for handling benchmark datasets uploaded through the BenchmarkIngestTool. It contains routines analogous to those in the sibling `models` module.