### PR TITLE
Add template files for benchmark variables

### DIFF
--- a/pbs_server/data/biomes.cfg.tmpl
+++ b/pbs_server/data/biomes.cfg.tmpl
@@ -1,0 +1,8 @@
+[h2: Biomes]
+variable = "biomes"
+
+[GFED]
+source = "DATA/biomes/GFED/biomes_0.5x0.5.nc"
+
+[TRIP]
+source = "DATA/biomes/TRIP/biomes_0.5x0.5.nc"

--- a/pbs_server/data/burntArea.cfg.tmpl
+++ b/pbs_server/data/burntArea.cfg.tmpl
@@ -1,0 +1,11 @@
+[h2: Burned Area Fraction]
+variable = "burntArea"
+
+[GFED3]
+source = "DATA/burntArea/GFED3/burntArea_0.5x0.5.nc"
+
+[GFED4]
+source = "DATA/burntArea/GFED3/burntArea_0.5x0.5.nc"
+
+[GFED4S]
+source = "DATA/burntArea/GFED3/burntArea_0.5x0.5.nc"

--- a/pbs_server/data/cmip5-variables.yaml
+++ b/pbs_server/data/cmip5-variables.yaml
@@ -7,6 +7,9 @@ albedo:
 biomass:
   long_name: Biomass
   benchmark_source: GlobalCarbon
+biomes:
+  long_name: Biomes
+  benchmark_source: GFED
 et:
   long_name: Evapotranspiration
   benchmark_source: MODIS

--- a/pbs_server/data/cmip5-variables.yaml
+++ b/pbs_server/data/cmip5-variables.yaml
@@ -7,6 +7,9 @@ albedo:
 biomass:
   long_name: Biomass
   benchmark_source: GlobalCarbon
+et:
+  long_name: Evapotranspiration
+  benchmark_source: MODIS
 gpp:
   long_name: GrossPrimaryProduction
   benchmark_source: Fluxnet-MTE

--- a/pbs_server/data/cmip5-variables.yaml
+++ b/pbs_server/data/cmip5-variables.yaml
@@ -10,6 +10,11 @@ biomass:
 biomes:
   long_name: Biomes
   benchmark_source: GFED
+burntArea:
+  long_name: BurnedAreaFraction
+  benchmark_source: GFED4S
+co2:
+landfraction:
 et:
   long_name: Evapotranspiration
   benchmark_source: MODIS
@@ -22,6 +27,7 @@ lai:
 le:
   long_name: LatentHeat
   benchmark_source: Fluxnet-MTE
+nbp:
 nee:
   long_name: NetEcosystemExchange
   benchmark_source: GBAF
@@ -30,10 +36,20 @@ pr:
   long_name: Precipitation
   benchmark_source: GPCP2
 reco:
+rhums:
+rlds:
+rlns:
+rlus:
+rns:
 rsds:
   long_name: SurfaceDownwardSWRadiation
   benchmark_source: CERES
+rsns:
 rsus:
+runoff:
+sh:
+soilc:
 tas:
   long_name: SurfaceAirTemperature
   benchmark_source: CRU
+twsa:

--- a/pbs_server/data/co2.cfg.tmpl
+++ b/pbs_server/data/co2.cfg.tmpl
@@ -1,0 +1,8 @@
+[h2: Carbon Dioxide]
+variable = "co2"
+
+[MAUNA.LOA]
+source = "DATA/co2/MAUNA.LOA/co2_1959-2013.nc"
+
+[NOAA.GMD]
+source = "DATA/co2/NOAA.GMD/co2.nc"

--- a/pbs_server/data/et.cfg.tmpl
+++ b/pbs_server/data/et.cfg.tmpl
@@ -1,0 +1,8 @@
+[h2: Evapotranspiration]
+variable = "et"
+
+[GLEAM]
+source = "DATA/et/GLEAM/et_0.5x0.5.nc"
+
+[MODIS]
+source = "DATA/et/MODIS/et_0.5x0.5.nc"

--- a/pbs_server/data/landfraction.cfg.tmpl
+++ b/pbs_server/data/landfraction.cfg.tmpl
@@ -1,0 +1,5 @@
+[h2: Land Area Fraction]
+variable = "landfraction"
+
+[MODIS]
+source = "DATA/landfraction/MODIS/landfraction_MODIS_0.5x0.5.nc"

--- a/pbs_server/data/nbp.cfg.tmpl
+++ b/pbs_server/data/nbp.cfg.tmpl
@@ -1,0 +1,12 @@
+[h2: Global Net Ecosystem Carbon Balance]
+variable = "nbp"
+weight   = 5
+ctype    = "ConfNBP"
+
+[GCP]
+source   = "DATA/nbp/GCP/nbp_1959-2012.nc"
+weight   = 20
+
+[Hoffman]
+source   = "DATA/nbp/HOFFMAN/nbp_1850-2010.nc"
+weight   = 20

--- a/pbs_server/data/rhums.cfg.tmpl
+++ b/pbs_server/data/rhums.cfg.tmpl
@@ -1,0 +1,5 @@
+[h2: Relative Humidity]
+variable = "rhums"
+
+[ERA]
+source = "DATA/rhums/ERA/rhums_0.5x0.5.nc"

--- a/pbs_server/data/rlds.cfg.tmpl
+++ b/pbs_server/data/rlds.cfg.tmpl
@@ -1,0 +1,11 @@
+[h2: Surface All Sky Downward Longwave Radiation]
+variable = "rlds"
+
+[CERES]
+source = "DATA/rlds/CERES/rlds_0.5x0.5.nc"
+
+[GEWEX.SRB]
+source = "DATA/rlds/GEWEX.SRB/rlds_0.5x0.5.nc"
+
+[WRMC.BSRN]
+source = "DATA/rlds/WRMC.BSRN/rlds.nc"

--- a/pbs_server/data/rlns.cfg.tmpl
+++ b/pbs_server/data/rlns.cfg.tmpl
@@ -1,0 +1,11 @@
+[h2: Surface All Sky Net Longwave Radiation]
+variable = "rlns"
+
+[CERES]
+source = "DATA/rlns/CERES/rlns_0.5x0.5.nc"
+
+[GEWEX.SRB]
+source = "DATA/rlns/GEWEX.SRB/rlns_0.5x0.5.nc"
+
+[WRMC.BSRN]
+source = "DATA/rlns/WRMC.BSRN/rlns.nc"

--- a/pbs_server/data/rlus.cfg.tmpl
+++ b/pbs_server/data/rlus.cfg.tmpl
@@ -1,0 +1,11 @@
+[h2: Surface All Sky Upward Longwave Radiation]
+variable = "rlus"
+
+[CERES]
+source = "DATA/rlus/CERES/rlus_0.5x0.5.nc"
+
+[GEWEX.SRB]
+source = "DATA/rlus/GEWEX.SRB/rlus_0.5x0.5.nc"
+
+[WRMC.BSRN]
+source = "DATA/rlus/WRMC.BSRN/rlus.nc"

--- a/pbs_server/data/rns.cfg.tmpl
+++ b/pbs_server/data/rns.cfg.tmpl
@@ -1,0 +1,14 @@
+[h2: Surface All Sky Net Radiation]
+variable = "rns"
+
+[CERES]
+source = "DATA/rns/CERES/rns_0.5x0.5.nc"
+
+[FLUXNET]
+source = "DATA/rns/FLUXNET/rns.nc"
+
+[GEWEX.SRB]
+source = "DATA/rns/GEWEX.SRB/rns_0.5x0.5.nc"
+
+[WRMC.BSRN]
+source = "DATA/rns/WRMC.BSRN/rns.nc"

--- a/pbs_server/data/rsns.cfg.tmpl
+++ b/pbs_server/data/rsns.cfg.tmpl
@@ -1,0 +1,11 @@
+[h2: Surface All Sky Net Shortwave Radiation]
+variable = "rsns"
+
+[CERES]
+source = "DATA/rsns/CERES/rsns_0.5x0.5.nc"
+
+[GEWEX.SRB]
+source = "DATA/rsns/GEWEX.SRB/rsns_0.5x0.5.nc"
+
+[WRMC.BSRN]
+source = "DATA/rsns/WRMC.BSRN/rsns.nc"

--- a/pbs_server/data/runoff.cfg.tmpl
+++ b/pbs_server/data/runoff.cfg.tmpl
@@ -1,0 +1,5 @@
+[h2: Runoff]
+variable = "runoff"
+
+[DAI]
+source = "DATA/runoff/Dai/runoff.nc"

--- a/pbs_server/data/sh.cfg.tmpl
+++ b/pbs_server/data/sh.cfg.tmpl
@@ -1,0 +1,8 @@
+[h2: Sensible Heat]
+variable = "sh"
+
+[FLUXNET]
+source = "DATA/sh/FLUXNET/sh.nc"
+
+[GBAF]
+source = "DATA/sh/GBAF/sh_0.5x0.5.nc"

--- a/pbs_server/data/soilc.cfg.tmpl
+++ b/pbs_server/data/soilc.cfg.tmpl
@@ -1,0 +1,8 @@
+[h2: Soil Carbon]%
+variable = "soilc"
+
+[HWSD]
+source = "DATA/soilc/HWSD/soilc_0.5x0.5.nc"
+
+[NCSCDV22]
+source = "DATA/soilc/NCSCDV22/soilc_0.5x0.5.nc"

--- a/pbs_server/data/twsa.cfg.tmpl
+++ b/pbs_server/data/twsa.cfg.tmpl
@@ -1,0 +1,5 @@
+[h2: Terrestrial Water Storage Anomaly]
+variable = "twsa"
+
+[GRACE]
+source = "DATA/twsa/GRACE/twsa_0.5x0.5.nc"

--- a/pbs_server/tests/test_ilambconfigfile.py
+++ b/pbs_server/tests/test_ilambconfigfile.py
@@ -10,7 +10,7 @@ from pbs_server import data_directory
 
 default_config_file = 'ilamb.cfg'
 default_config_file_path = os.path.join(data_directory, default_config_file)
-n_sources = 12
+n_sources = 14
 gpp_template_file = 'gpp.cfg.tmpl'
 relationship = '"LeafAreaIndex/AVHRR"'
 default_title = 'Permafrost Benchmark System'

--- a/pbs_server/tests/test_ilambconfigfile.py
+++ b/pbs_server/tests/test_ilambconfigfile.py
@@ -10,7 +10,7 @@ from pbs_server import data_directory
 
 default_config_file = 'ilamb.cfg'
 default_config_file_path = os.path.join(data_directory, default_config_file)
-n_sources = 14
+n_sources = 28
 gpp_template_file = 'gpp.cfg.tmpl'
 relationship = '"LeafAreaIndex/AVHRR"'
 default_title = 'Permafrost Benchmark System'


### PR DESCRIPTION
This PR adds template files for all benchmark variables in the ILAMB DATA directory. This fixes #7.